### PR TITLE
fix: Make Uno.WinUI conditional to Uno targets

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/LiveChartsCore.SkiaSharpView.Uno.WinUI.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/LiveChartsCore.SkiaSharpView.Uno.WinUI.csproj
@@ -25,7 +25,10 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.WinUI" Version="5.0.19" />
+    <PackageReference 
+      Condition="!$(TargetFramework.Contains('-windows'))" 
+      Include="Uno.WinUI" Version="5.0.19" />
+
     <ProjectReference Include="..\LiveChartsCore.SkiaSharp\LiveChartsCore.SkiaSharpView.csproj" />
     <ProjectReference Include="..\..\LiveChartsCore.Behaviours\LiveChartsCore.Behaviours.csproj" />
     


### PR DESCRIPTION
This avoids a duplicate resources issue that has been fixed in https://github.com/microsoft/microsoft-ui-xaml/issues/8857.

While upgrading WinAppSDK would also fix the issue, it's best to remove the dependency altogether.

Without this fix, the error can appear as follows:

```
ERROR: PRI175: 0x80073b0f - Processing Resources failed with error: Duplicate Entry.
ERROR: PRI277: 0x80073b0f - Conflicting values for resource 'Files/Uno.UI.Toolkit/Themes/Generic.xbf'
```